### PR TITLE
feat(st-18): Send login API responses as expected

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "bcrypt", "~> 3.1.7"
 gem "pundit"
 gem "doorkeeper"
 gem "interactor"
+gem 'panko_serializer'  
 gem "dotenv-rails", groups: [ :development, :test ]
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "bcrypt", "~> 3.1.7"
 gem "pundit"
 gem "doorkeeper"
 gem "interactor"
-gem 'panko_serializer'  
+gem "panko_serializer"
 gem "dotenv-rails", groups: [ :development, :test ]
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-linux-musl)
       racc (~> 1.4)
+    oj (3.16.9)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     ostruct (0.6.1)
+    panko_serializer (0.8.3)
+      activesupport
+      oj (> 3.11.0, < 4.0.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -335,10 +341,11 @@ DEPENDENCIES
   dotenv-rails
   interactor
   kamal
+  panko_serializer
   pg (>= 0.18, < 2.0)
   puma (>= 5.0)
-  rack-cors
   pundit
+  rack-cors
   rails (~> 8.0.1)
   rubocop-rails-omakase
   solid_cable

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -18,7 +18,7 @@ module Api
           )
         else
           error_response(
-            message: [result.message],
+            message: [ result.message ],
             status: :unauthorized,
             error: UNAUTHORIZED
           )

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,6 +1,9 @@
 module Api
   module V1
     class SessionsController < ApplicationController
+      AUTHENTICATION_SUCCESSFUL = "Authentication successful"
+      UNAUTHORIZED = "Unauthorized"
+
       def create
         result = Users::AuthenticateUser.call(email: params[:email], password: params[:password])
 
@@ -9,22 +12,15 @@ module Api
           success_response(
             data: {
               accessToken: result.token,
-              user: {
-                id: user.id,
-                first_name: user.first_name,
-                last_name: user.last_name,
-                gender: user.gender,
-                email: user.email,
-                user_type: user.user_type.upcase
-              }
+              user: UserSerializer.new.serialize(user)
             },
-            message: BaseInteractor::AUTHENTICATION_SUCCESSFUL
+            message: AUTHENTICATION_SUCCESSFUL
           )
         else
           error_response(
-            message: result.message,
+            message: [result.message],
             status: :unauthorized,
-            error: BaseInteractor::UNAUTHORIZED
+            error: UNAUTHORIZED
           )
         end
       end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -5,9 +5,27 @@ module Api
         result = Users::AuthenticateUser.call(email: params[:email], password: params[:password])
 
         if result.success?
-          render json: { token: result.token }, status: :ok
+          user = result.user
+          success_response(
+            data: {
+              accessToken: result.token,
+              user: {
+                id: user.id,
+                first_name: user.first_name,
+                last_name: user.last_name,
+                gender: user.gender,
+                email: user.email,
+                user_type: user.user_type.upcase
+              }
+            },
+            message: BaseInteractor::AUTHENTICATION_SUCCESSFUL
+          )
         else
-          render json: { error: result.message }, status: :unauthorized
+          error_response(
+            message: result.message,
+            status: :unauthorized,
+            error: BaseInteractor::UNAUTHORIZED
+          )
         end
       end
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,32 @@
+module Api
+    module V1
+      class UsersController < ApplicationController
+        before_action :doorkeeper_authorize!
+  
+        USER_DATA_RETRIEVED = "User data retrieved successfully"
+        USER_DATA_NOT_RETRIEVED = "User data could not be retrieved"
+
+        def me
+          user = current_user
+          if user
+            success_response(
+              data: UserSerializer.new.serialize(user),
+              message: USER_DATA_RETRIEVED
+            )
+          else
+            error_response(
+              message: [USER_DATA_NOT_RETRIEVED],
+              status: :not_found,
+              error: BaseInteractor::NOT_FOUND_ERROR
+            )
+          end
+        end
+  
+        private
+  
+        def current_user
+          @current_user ||= User.find_by(id: doorkeeper_token.resource_owner_id) if doorkeeper_token
+        end
+      end
+    end
+  end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ module Api
     module V1
       class UsersController < ApplicationController
         before_action :doorkeeper_authorize!
-  
+
         USER_DATA_RETRIEVED = "User data retrieved successfully"
         USER_DATA_NOT_RETRIEVED = "User data could not be retrieved"
 
@@ -15,18 +15,18 @@ module Api
             )
           else
             error_response(
-              message: [USER_DATA_NOT_RETRIEVED],
+              message: [ USER_DATA_NOT_RETRIEVED ],
               status: :not_found,
               error: BaseInteractor::NOT_FOUND_ERROR
             )
           end
         end
-  
+
         private
-  
+
         def current_user
           @current_user ||= User.find_by(id: doorkeeper_token.resource_owner_id) if doorkeeper_token
         end
       end
     end
-  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+    include ResponseHelper
     include Pundit::Authorization
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/app/controllers/concerns/response_helper.rb
+++ b/app/controllers/concerns/response_helper.rb
@@ -1,22 +1,19 @@
 module ResponseHelper
-    def success_response(data:, message:, status: :ok)
-      response = {
-        statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
-        message: message,
-        data: data
-      }
-      render json: response, status: status
-    end
+  def success_response(data:, message:, status: :ok)
+    response = {
+      statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
+      message: message,
+      data: data
+    }
+    render json: response, status: status
+  end
 
-    def error_response(message:, status:, error:)
-      response = {
-        status: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
-        data: {
-          statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
-          message: message,
-          error: error
-        }
-      }
-      render json: response, status: status
-    end
+  def error_response(message:, status:, error:)
+    response = {
+      statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
+      message: Array(message),
+      error: error
+    }
+    render json: response, status: status
+  end
 end

--- a/app/controllers/concerns/response_helper.rb
+++ b/app/controllers/concerns/response_helper.rb
@@ -1,0 +1,22 @@
+module ResponseHelper
+    def success_response(data:, message:, status: :ok)
+      response = {
+        statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
+        message: message,
+        data: data
+      }
+      render json: response, status: status
+    end
+
+    def error_response(message:, status:, error:)
+      response = {
+        status: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
+        data: {
+          statusCode: Rack::Utils::SYMBOL_TO_STATUS_CODE[status],
+          message: message,
+          error: error
+        }
+      }
+      render json: response, status: status
+    end
+end

--- a/app/interactors/base_interactor.rb
+++ b/app/interactors/base_interactor.rb
@@ -2,10 +2,9 @@ class BaseInteractor
     include Interactor
 
     SOMETHING_WENT_WRONG = "Something went wrong"
-    UNAUTHORIZED = "Unauthorized"
     NOT_AUTHORIZED_MESSAGE = "You are not authorized to perform this action."
     MISSING_PARAMS = "Missing params: "
-    AUTHENTICATION_SUCCESSFUL = "Authentication successful"
+    NOT_FOUND_ERROR = "Not Found"
 
     def validate_params(required_params)
       missing_params = required_params.select { |param| context[param].nil? }

--- a/app/interactors/base_interactor.rb
+++ b/app/interactors/base_interactor.rb
@@ -4,6 +4,8 @@ class BaseInteractor
     SOMETHING_WENT_WRONG = "Something went wrong"
     UNAUTHORIZED = "Unauthorized"
     NOT_AUTHORIZED_MESSAGE = "You are not authorized to perform this action."
+    MISSING_PARAMS = "Missing params: "
+    AUTHENTICATION_SUCCESSFUL = "Authentication successful"
 
     def validate_params(required_params)
       missing_params = required_params.select { |param| context[param].nil? }

--- a/app/interactors/users/authenticate_user.rb
+++ b/app/interactors/users/authenticate_user.rb
@@ -1,6 +1,5 @@
 class Users::AuthenticateUser < BaseInteractor
   REQUIRED_PARAMS = %i[email password].freeze
-
   INVALID_CREDENTIALS = "Invalid credentials"
 
   delegate(*REQUIRED_PARAMS, to: :context)

--- a/app/interactors/users/authenticate_user.rb
+++ b/app/interactors/users/authenticate_user.rb
@@ -19,6 +19,7 @@ class Users::AuthenticateUser < BaseInteractor
           expires_in: Doorkeeper.configuration.access_token_expires_in.to_i,
           scopes: ""
         )
+        context.user = user
         context.token = token.token
       else
         context.fail!(message: INVALID_CREDENTIALS)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,8 @@
+class UserSerializer < Panko::Serializer
+    attributes :id, :first_name, :last_name, :gender, :email, :user_type
+  
+    def user_type
+      object.user_type.upcase
+    end
+  end
+  

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,8 +1,7 @@
 class UserSerializer < Panko::Serializer
     attributes :id, :first_name, :last_name, :gender, :email, :user_type
-  
+
     def user_type
       object.user_type.upcase
     end
-  end
-  
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "login", to: "sessions#create"
+      get 'users/me', to: 'users#me'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "login", to: "sessions#create"
-      get 'users/me', to: 'users#me'
+      get "users/me", to: "users#me"
     end
   end
 end

--- a/test/controllers/api/v1/sessions_controller_test.rb
+++ b/test/controllers/api/v1/sessions_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SessionsControllerTest < ActionDispatch::IntegrationTest
+class Api::V1::SessionsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @user = users(:one)
     @student = students(:one)
@@ -28,32 +28,32 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test "should not login with invalid email" do
     post api_v1_login_url, params: { email: "invalid@example.com", password: "Password1!" }, as: :json
-    assert_response :unauthorized
-    assert_equal 401, json_response["data"]["statusCode"]
-    assert_equal "Invalid credentials", json_response["data"]["message"]
-    assert_equal "Unauthorized", json_response["data"]["error"]
+    assert_unauthorized_response
   end
 
   test "should not login with invalid password" do
     post api_v1_login_url, params: { email: @user.email, password: "wrongpassword" }, as: :json
-    assert_response :unauthorized
-    assert_equal 401, json_response["data"]["statusCode"]
-    assert_equal "Invalid credentials", json_response["data"]["message"]
-    assert_equal "Unauthorized", json_response["data"]["error"]
+    assert_unauthorized_response
   end
 
   test "should not login if student record does not exist" do
     @student.destroy
     post api_v1_login_url, params: { email: @user.email, password: "Password1!" }, as: :json
-    assert_response :unauthorized
-    assert_equal 401, json_response["data"]["statusCode"]
-    assert_equal "Invalid credentials", json_response["data"]["message"]
-    assert_equal "Unauthorized", json_response["data"]["error"]
+    assert_unauthorized_response
   end
 
   private
 
   def json_response
     JSON.parse(response.body)
+  end
+
+  def assert_unauthorized_response
+    assert_response :unauthorized
+    assert_not_nil response.body, "Response body should not be nil"
+    assert_not_nil json_response, "JSON response should not be nil"
+    assert_equal 401, json_response["statusCode"]
+    assert_equal [ "Invalid credentials" ], json_response["message"]
+    assert_equal "Unauthorized", json_response["error"]
   end
 end

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:one)
+    @application = Doorkeeper::Application.create!(
+      name: ENV["DOORKEEPER_APP_NAME"],
+      redirect_uri: ENV["DOORKEEPER_REDIRECT_URI"],
+      uid: ENV["DOORKEEPER_CLIENT_ID"],
+      secret: ENV["DOORKEEPER_CLIENT_SECRET"]
+    )
+    @token = Doorkeeper::AccessToken.create!(
+      resource_owner_id: @user.id,
+      application_id: @application.id,
+      expires_in: Doorkeeper.configuration.access_token_expires_in.to_i,
+      scopes: ""
+    )
+  end
+
+  test "should get current user data with valid token" do
+    get api_v1_users_me_url, headers: { Authorization: "Bearer #{@token.token}" }, as: :json
+    assert_response :success
+    assert_equal 200, json_response["statusCode"]
+    assert_equal "User data retrieved successfully", json_response["message"]
+    assert_equal @user.id, json_response["data"]["id"]
+    assert_equal @user.first_name, json_response["data"]["first_name"]
+    assert_equal @user.last_name, json_response["data"]["last_name"]
+    assert_equal @user.gender, json_response["data"]["gender"]
+    assert_equal @user.email, json_response["data"]["email"]
+    assert_equal @user.user_type.upcase, json_response["data"]["user_type"]
+  end
+
+  test "should not get user data with invalid token" do
+    get api_v1_users_me_url, headers: { Authorization: "Bearer invalid_token" }, as: :json
+    assert_response :unauthorized
+  end
+
+  test "should not get user data without token" do
+    get api_v1_users_me_url, as: :json
+    assert_response :unauthorized
+  end
+
+  private
+
+  def json_response
+    return {} if response.body.blank?
+    JSON.parse(response.body)
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -15,26 +15,40 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test "should login with valid credentials and student record" do
     post api_v1_login_url, params: { email: @user.email, password: "Password1!" }, as: :json
     assert_response :success
-    assert_not_nil json_response["token"]
+    assert_equal 200, json_response["statusCode"]
+    assert_equal "Authentication successful", json_response["message"]
+    assert_not_nil json_response["data"]["accessToken"]
+    assert_equal @user.id, json_response["data"]["user"]["id"]
+    assert_equal @user.first_name, json_response["data"]["user"]["first_name"]
+    assert_equal @user.last_name, json_response["data"]["user"]["last_name"]
+    assert_equal @user.gender, json_response["data"]["user"]["gender"]
+    assert_equal @user.email, json_response["data"]["user"]["email"]
+    assert_equal @user.user_type.upcase, json_response["data"]["user"]["user_type"]
   end
 
   test "should not login with invalid email" do
     post api_v1_login_url, params: { email: "invalid@example.com", password: "Password1!" }, as: :json
     assert_response :unauthorized
-    assert_equal "Invalid credentials", json_response["error"]
+    assert_equal 401, json_response["data"]["statusCode"]
+    assert_equal "Invalid credentials", json_response["data"]["message"]
+    assert_equal "Unauthorized", json_response["data"]["error"]
   end
 
   test "should not login with invalid password" do
     post api_v1_login_url, params: { email: @user.email, password: "wrongpassword" }, as: :json
     assert_response :unauthorized
-    assert_equal "Invalid credentials", json_response["error"]
+    assert_equal 401, json_response["data"]["statusCode"]
+    assert_equal "Invalid credentials", json_response["data"]["message"]
+    assert_equal "Unauthorized", json_response["data"]["error"]
   end
 
   test "should not login if student record does not exist" do
     @student.destroy
     post api_v1_login_url, params: { email: @user.email, password: "Password1!" }, as: :json
     assert_response :unauthorized
-    assert_equal "Invalid credentials", json_response["error"]
+    assert_equal 401, json_response["data"]["statusCode"]
+    assert_equal "Invalid credentials", json_response["data"]["message"]
+    assert_equal "Unauthorized", json_response["data"]["error"]
   end
 
   private


### PR DESCRIPTION
## Description of Change

1.   Send login API success and error responses as expected in Frontend
2.  Test API responses and ensure they pass

### Updates

3. Create users endpoint to send user data upon authorization
4. Create tests for users endpoint and ensure they pass
5. Serialize json responses

## Associated Ticket Link(s)

- https://trello.com/c/SZ7SUWow

## Screenshots / Screen Recordings

1. 

a. Success response: 
![login_response_success](https://github.com/user-attachments/assets/c2cf89f5-bd61-432e-be7e-919e4a424da2)

b. Error response: 
![login response_error](https://github.com/user-attachments/assets/7d096c86-e5c5-483f-87f2-60a6aecec702)

2. 
![login_response_test](https://github.com/user-attachments/assets/6f5165ea-437b-4028-bf28-81af264036bc)

4. 
![users_test](https://github.com/user-attachments/assets/3a973602-80c7-4d5d-9f5f-8b601b96b41b)


## Dev notes

1. Implement FE logic to login
2. Test FE login with API