### PR TITLE
feat(st-49): Create functionality to store and broadcast notifications for classwork creation

### DIFF
--- a/app/controllers/api/v1/classwork/assignments_controller.rb
+++ b/app/controllers/api/v1/classwork/assignments_controller.rb
@@ -5,6 +5,7 @@ module Api
         include ResponseHelper
         include Constants::ClassworkConstants
         include FileUploadable
+        include NotificationSender
         before_action :doorkeeper_authorize!
 
         def create_assignment
@@ -37,6 +38,9 @@ module Api
           end
 
           result.assignment.update!(file_url: upload_result[:data][:file_url])
+
+          create_notifications_for_assignment(result.assignment.id)
+
           success_response(data: result.assignment, message: ASSIGNMENT_CREATION_SUCCESS)
         end
 
@@ -115,7 +119,7 @@ module Api
             error: ASSIGNMENT_CREATION_FAIL
           ) unless assignment
 
-          current_time = Time.current.in_time_zone("Dhaka")
+          current_time = Time.current.in_time_zone(DEFAULT_TIMEZONE)
           past_due_date = ::Classwork::Submission.check_if_late?(current_time, assignment.due_date)
 
           if past_due_date

--- a/app/controllers/concerns/notification_sender.rb
+++ b/app/controllers/concerns/notification_sender.rb
@@ -1,0 +1,33 @@
+module NotificationSender
+    extend ActiveSupport::Concern
+
+    def create_notifications_for_assignment(assignment_id)
+      begin
+        require "net/http"
+        require "uri"
+
+        protocol = request.protocol # "http://" or "https://"
+        host_with_port = request.host_with_port # "example.com:3000" or "localhost:3000"
+        base_url = "#{protocol}#{host_with_port}"
+
+        uri = URI.parse("#{base_url}/api/v1/classrooms/notifications/#{assignment_id}")
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
+
+        req = Net::HTTP::Post.new(uri.path)
+        req["Authorization"] = request.headers["Authorization"]
+        req["Content-Type"] = "application/json"
+
+        response = http.request(req)
+
+        if response.code.to_i.between?(200, 299)
+          Rails.logger.info("Successfully created notifications for assignment #{assignment_id}")
+        else
+          Rails.logger.warn("Failed to create notifications for assignment #{assignment_id}: #{response.body}")
+        end
+      rescue StandardError => e
+        Rails.logger.error("Error when creating notifications for assignment #{assignment_id}: #{e.message}")
+      end
+    end
+end

--- a/app/interactors/classrooms/create_assignment_notification.rb
+++ b/app/interactors/classrooms/create_assignment_notification.rb
@@ -1,0 +1,69 @@
+module Classrooms
+    class CreateAssignmentNotification
+      include Interactor
+      include Constants::ClassroomConstants
+      include Constants::ClassworkConstants
+
+      def call
+        assignment = context.assignment
+        Rails.logger.info "Creating notifications for assignment: #{assignment.title}"
+
+        classroom_users = assignment.classroom.users
+        teacher_id = assignment.classroom.teacher_id
+        student_users = classroom_users.reject { |user| user.id == teacher_id }
+
+        notifications = []
+
+        student_users.each do |user|
+           next if Classwork::Notification.exists?(
+            assignment_id: assignment.id,
+            receiver_id: user.id,
+            notification_type: CLASSWORK_CREATION
+          )
+
+          notifications << Classwork::Notification.create!(
+            assignment_id: assignment.id,
+            receiver_id: user.id,
+            notification_type: CLASSWORK_CREATION,
+            title: "Classwork Created",
+            message: "#{assignment.title} #{assignment.assignment_type} has been uploaded",
+            is_read: false
+          )
+        end
+
+        if notifications.any?
+          broadcast_classwork_creation(assignment, notifications)
+        end
+
+        context.notifications = notifications
+      rescue StandardError => e
+        Rails.logger.error "Failed to create assignment notifications: #{e.message}"
+        context.fail!(message: ASSIGNMENT_NOTIFICATION_FAIL, error: e.message)
+      end
+
+      private
+
+      def broadcast_classwork_creation(assignment, notifications)
+        Rails.logger.info "Broadcasting classwork creation notification for assignment: #{assignment.title}"
+
+        classroom_title = assignment.classroom&.title
+
+        ActionCable.server.broadcast(
+          "classroom_notifications_channel_#{assignment.classroom_id}",
+          {
+            type: CLASSWORK_CREATION,
+            assignment_id: assignment.id,
+            notification_ids: notifications.map(&:id),
+            classroom_id: assignment.classroom_id,
+            classroom_title: classroom_title,
+            title: "Classwork Created",
+            message: "#{assignment.title} #{assignment.assignment_type} has been uploaded",
+            created_at: Time.current.in_time_zone(DEFAULT_TIMEZONE)
+          }
+        )
+
+        notifications.each { |n| n.update!(broadcast_at: Time.current.in_time_zone(DEFAULT_TIMEZONE)) }
+        Rails.logger.info "Marked #{notifications.count} notifications as broadcast"
+      end
+    end
+end

--- a/app/interactors/classrooms/get_unread_notifications_for_user.rb
+++ b/app/interactors/classrooms/get_unread_notifications_for_user.rb
@@ -16,7 +16,7 @@ module Classrooms
       private
 
       def fetch_unread_notifications
-        ::Classwork::Notification
+        Classwork::Notification
           .includes(assignment: :classroom)
           .where(receiver_id: context.user_id, is_read: false)
           .order(created_at: :desc)

--- a/app/interactors/classrooms/get_user_notifications.rb
+++ b/app/interactors/classrooms/get_user_notifications.rb
@@ -16,7 +16,7 @@ module Classrooms
       private
 
       def fetch_notifications
-        ::Classwork::Notification
+        Classwork::Notification
           .includes(assignment: :classroom)
           .where(receiver_id: context.user_id)
           .order(created_at: :desc)

--- a/app/interactors/classrooms/update_notifications_read.rb
+++ b/app/interactors/classrooms/update_notifications_read.rb
@@ -13,7 +13,7 @@ module Classrooms
           )
         end
 
-        updated_count = ::Classwork::Notification
+        updated_count = Classwork::Notification
           .where(id: notification_ids)
           .update_all(is_read: true)
 

--- a/app/interactors/classwork/create_submission.rb
+++ b/app/interactors/classwork/create_submission.rb
@@ -24,7 +24,7 @@ module Classwork
         )
       end
 
-      submitted_at = Time.current.in_time_zone("Dhaka")
+      submitted_at = Time.current.in_time_zone(DEFAULT_TIMEZONE)
       is_late = Submission.che ck_if_late?(submitted_at, assignment.due_date)
 
       submission = Submission.create!(

--- a/app/interactors/classwork/update_assignment_fields.rb
+++ b/app/interactors/classwork/update_assignment_fields.rb
@@ -12,7 +12,7 @@ module Classwork
         ) unless assignment
 
         if assignment.assignment_type == "exam"
-          current_time = Time.current.in_time_zone("Dhaka")
+          current_time = Time.current.in_time_zone(DEFAULT_TIMEZONE)
           past_due_date = Submission.check_if_late?(current_time, assignment.due_date)
 
           if past_due_date

--- a/app/interactors/classwork/update_submission.rb
+++ b/app/interactors/classwork/update_submission.rb
@@ -15,7 +15,7 @@ module Classwork
       private
 
       def update_submission
-        submitted_at = Time.current.in_time_zone("Dhaka")
+        submitted_at = Time.current.in_time_zone(DEFAULT_TIMEZONE)
         is_late = Submission.check_if_late?(submitted_at, context.submission.assignment.due_date)
 
         context.submission.update!(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         get "notifications/:user_id", to: "notifications#get_user_notifications"
         get "notifications/:user_id/unread", to: "notifications#get_unread_notifications_for_user"
         put "notifications/mark_read", to: "notifications#update_notifications_read"
+        post "notifications/:assignment_id", to: "notifications#create_assignment_notification"
       end
 
       # Classwork routes

--- a/lib/constants/classroom_constants.rb
+++ b/lib/constants/classroom_constants.rb
@@ -44,5 +44,7 @@ module Constants
       NOTIFICATION_UPDATE_FAIL = "Failed to update notifications".freeze
       NO_NOTIFICATION_IDS_PROVIDED = "No notification IDs provided".freeze
       MISSING_NOTIFICATION_IDS = "Missing notification IDs".freeze
+      ASSIGNMENT_NOTIFICATION_SUCCESS = "Assignment notifications created successfully".freeze
+      ASSIGNMENT_NOTIFICATION_FAIL = "Failed to create assignment notifications".freeze
     end
 end

--- a/lib/constants/classwork_constants.rb
+++ b/lib/constants/classwork_constants.rb
@@ -8,6 +8,7 @@ module Constants
       ASSIGNMENT_DELETE_SUCCESS = "Assignment deleted successfully".freeze
       ASSIGNMENT_DELETE_FAIL = "Assignment deletion failed".freeze
       ASSIGNMENT_NOT_FOUND = "Assignment not found".freeze
+      INVALID_ASSIGNMENT_ID = "Invalid assignment ID".freeze
       ASSIGNMENTS_RETRIEVE_SUCCESS = "Assignments retrieved successfully".freeze
       ASSIGNMENTS_RETRIEVE_FAIL = "Failed to retrieve assignments".freeze
       ERROR_NO_ASSIGNMENTS = "NO_ASSIGNMENTS_FOUND".freeze
@@ -37,5 +38,9 @@ module Constants
       SUBMISSIONS_RETRIEVE_SUCCESS = "Submissions retrieved successfully".freeze
       SUBMISSIONS_RETRIEVE_FAIL = "Failed to retrieve submissions".freeze
       NO_SUBMISSIONS_FOUND = "No submissions found for this assignment".freeze
+
+      DEFAULT_TIMEZONE = "Dhaka".freeze
+      CLASSWORK_CREATION = "classwork_creation".freeze
+      EXAM_REMINDER = "exam_reminder".freeze
     end
 end


### PR DESCRIPTION
## Description of Change

1. Notifications for assignment/exam creation are stored in the notifications table
2. The notification is broadcast to students in the classroom after it is stored

- [x] **You assure that you have tested the modules properly and there are no breaking changes**
- [x] **You adhere to Sazim's [Engineering Principles](https://docs.google.com/document/d/10mowIwsuYMyNkXS7aeL7AJyVNMYVh1vdMf7yn-A6I1k/edit#heading=h.qqetrc8w2lm8)**

## Associated Ticket Link(s)

-  https://trello.com/c/fVhW7OwI

## Dev notes

- Implement logic to store and broadcast notifications when classwork material is created
